### PR TITLE
Fix to layoutAttributesForElements crashing when moving from non-zero elements to zero.

### DIFF
--- a/Sources/FSPageViewLayout.swift
+++ b/Sources/FSPageViewLayout.swift
@@ -117,6 +117,9 @@ class FSPagerViewLayout: UICollectionViewLayout {
     
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         var layoutAttributes = [UICollectionViewLayoutAttributes]()
+        guard self.numberOfItems > 0 else {
+            return layoutAttributes
+        }
         guard self.itemSpacing > 0, !rect.isEmpty else {
             return layoutAttributes
         }


### PR DESCRIPTION
Had a crash happen when moving from non-zero elements to zero, when the items in the FSPagerView where powered by a fetched results controller.