### PR TITLE
Modify the bug

### DIFF
--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -522,6 +522,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
             return
         }
         self.timer = Timer.scheduledTimer(timeInterval: TimeInterval(self.automaticSlidingInterval), target: self, selector: #selector(self.flipNext(sender:)), userInfo: nil, repeats: true)
+        RunLoop.current.add(self.timer!, forMode: .UITrackingRunLoopMode)
     }
     
     @objc


### PR DESCRIPTION
: hello, the author, I am a development from China, my name is suger,
currently located in Beijing, in the framework of with you, find
embedded in tableview cell, the finger touches the tableview Image does
not automatically scroll to the timer to join the runloop slide in
tableview also in rolling.You can have a try, if there is a problem can
be sent to my mailbox 819950208 @qq.com