### PR TITLE
fix the bug of scroll position in selectItem function

### DIFF
--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -463,7 +463,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     @objc(selectItemAtIndex:animated:)
     open func selectItem(at index: Int, animated: Bool) {
         let indexPath = self.nearbyIndexPath(for: index)
-        let scrollPosition: UICollectionViewScrollPosition = self.scrollDirection == .horizontal ? .centeredVertically : .centeredVertically
+        let scrollPosition: UICollectionViewScrollPosition = self.scrollDirection == .horizontal ? .centeredHorizontally : .centeredVertically
         self.collectionView.selectItem(at: indexPath, animated: animated, scrollPosition: scrollPosition)
     }
     


### PR DESCRIPTION
@WenchaoD  I think the code below seems wrong: 

```
 let scrollPosition: UICollectionViewScrollPosition = self.scrollDirection == .horizontal ? .centeredVertically : .centeredVertically
```
when the scroll direction is horizontal , the value of `scrollPosition` should be `.centeredHorizontally`

Hope you can review it !