### PR TITLE
Add one missing case to catch the scrolling end callback of FSPagerView.

### DIFF
--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -410,6 +410,14 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
         }
     }
     
+    public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if !decelerate {
+            if let function = self.delegate?.pagerViewDidEndDecelerating {
+                function(self)
+            }
+        }
+    }
+    
     // MARK: - Public functions
     
     /// Register a class for use in creating new pager view cells.


### PR DESCRIPTION

Fix bug described in issue #137. 

> Normally, I used **pagerViewDidEndScrollAnimation** or **pagerViewDidEndDecelerating** to determine whether the pagerView has ended the scrolling action. But there is another case should be added in **FSPagerView.swift** :

```
public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) { 
     //When scrollView DidEndDragging and isn`t decelerated
     if !delcelerate {
          //Need to add one case to catch the pagerView has ended scrolling here.
     } 
 }
```