### PR TITLE
There is a bug in calculating targetIndex in case item size is small …

### DIFF
--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -417,7 +417,17 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
         if let function = self.delegate?.pagerViewWillEndDragging(_:targetIndex:) {
             let contentOffset = self.scrollDirection == .horizontal ? targetContentOffset.pointee.x : targetContentOffset.pointee.y
             let targetItem = lround(Double(contentOffset/self.collectionViewLayout.itemSpacing))
-            function(self, targetItem % self.numberOfItems)
+            var targetIndex: Int
+            if isInfinite {
+                targetIndex = targetItem % self.numberOfItems
+            } else {
+                if targetItem < self.numberOfItems {
+                    targetIndex = targetItem % self.numberOfItems
+                } else {
+                    targetIndex = max(self.numberOfItems - 1, 0)
+                }
+            }
+            function(self, targetIndex)
         }
         if self.automaticSlidingInterval > 0 {
             self.startTimer()


### PR DESCRIPTION
There is a bug in calculating targetIndex in case item size is small like 50% of screen width and isInfinite = false.
Basically if you swipe to the last (rightmost) item in the list and then swipe again from right to left, the `targetItem % self.numberOfItems` would be something like 7 % 7 for 7 items in the list, which gives 0 in result. For isInfinite = true this is correct logic, but for isInfinite = false it causes pageControl to display the very first page and delegates `pagerViewWillEndDragging` and `pagerViewDidEndScrollAnimation` will give you incorrect `targetIndex` or `pagerView.currentIndex`.
This piece of code fixes the issue.