### PR TITLE
Add collectionViewClipsToBounds to set the clipsToBounds.

### DIFF
--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -192,7 +192,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
         }
     }
 
-    /// Whether or not the pager clipsToBounds/masksToBounds. Set to false if you want the cells to be able to bleed outside the collection view.
+    /// Whether or not the pager clipsToBounds/masksToBounds. Set to false if you want the cells to be able to bleed outside the collection view.  The default is true.
     open var collectionViewClipsToBounds: Bool = true {
         didSet {
             self.collectionView.clipsToBounds = self.collectionViewClipsToBounds

--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -191,6 +191,13 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
             self.collectionViewLayout.forceInvalidate()
         }
     }
+
+    /// Whether or not the pager clipsToBounds/masksToBounds. Set to false if you want the cells to be able to bleed outside the collection view.
+    open var collectionViewClipsToBounds: Bool = true {
+        didSet {
+            self.collectionView.clipsToBounds = self.collectionViewClipsToBounds
+        }
+    }
     
     // MARK: - Public readonly-properties
     


### PR DESCRIPTION
On occasion, i've had to make FSPagerCells that have shadow borders that bleed outside of the cell (and thus outside the underlying UICollectionView).  This Pull Request adds the ability to set the collectionViewClipsToBounds parameter so allow or disallow this behavior. 