### PR TITLE
Easy create custom design cell

### DIFF
--- a/FSPageViewExample-Swift/FSPagerViewExample/BasicExampleViewController.swift
+++ b/FSPageViewExample-Swift/FSPagerViewExample/BasicExampleViewController.swift
@@ -163,8 +163,8 @@ class BasicExampleViewController: UIViewController,UITableViewDataSource,UITable
         return self.numberOfItems
     }
     
-    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewCell {
-        let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index)
+    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell {
+        let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as! FSPagerViewCell
         cell.imageView?.image = UIImage(named: self.imageNames[index])
         cell.imageView?.contentMode = .scaleAspectFill
         cell.imageView?.clipsToBounds = true

--- a/FSPageViewExample-Swift/FSPagerViewExample/BasicExampleViewController.swift
+++ b/FSPageViewExample-Swift/FSPagerViewExample/BasicExampleViewController.swift
@@ -163,7 +163,7 @@ class BasicExampleViewController: UIViewController,UITableViewDataSource,UITable
         return self.numberOfItems
     }
     
-    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell {
+    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> UICollectionViewCell {
         let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as! FSPagerViewCell
         cell.imageView?.image = UIImage(named: self.imageNames[index])
         cell.imageView?.contentMode = .scaleAspectFill

--- a/FSPageViewExample-Swift/FSPagerViewExample/PageControlExampleViewController.swift
+++ b/FSPageViewExample-Swift/FSPagerViewExample/PageControlExampleViewController.swift
@@ -215,8 +215,8 @@ class PageControlExampleViewController: UIViewController,UITableViewDataSource,U
         return self.imageNames.count
     }
     
-    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewCell {
-        let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index)
+    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell {
+        let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as! FSPagerViewCell
         cell.imageView?.image = UIImage(named: self.imageNames[index])
         cell.imageView?.contentMode = .scaleAspectFill
         return cell

--- a/FSPageViewExample-Swift/FSPagerViewExample/PageControlExampleViewController.swift
+++ b/FSPageViewExample-Swift/FSPagerViewExample/PageControlExampleViewController.swift
@@ -215,7 +215,7 @@ class PageControlExampleViewController: UIViewController,UITableViewDataSource,U
         return self.imageNames.count
     }
     
-    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell {
+    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> UICollectionViewCell {
         let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as! FSPagerViewCell
         cell.imageView?.image = UIImage(named: self.imageNames[index])
         cell.imageView?.contentMode = .scaleAspectFill

--- a/FSPageViewExample-Swift/FSPagerViewExample/TransformerExampleViewController.swift
+++ b/FSPageViewExample-Swift/FSPagerViewExample/TransformerExampleViewController.swift
@@ -99,8 +99,8 @@ class TransformerExampleViewController: UIViewController,FSPagerViewDataSource,F
         return imageNames.count
     }
     
-    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewCell {
-        let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index)
+    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell {
+        let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as! FSPagerViewCell
         cell.imageView?.image = UIImage(named: self.imageNames[index])
         cell.imageView?.contentMode = .scaleAspectFill
         cell.imageView?.clipsToBounds = true

--- a/FSPageViewExample-Swift/FSPagerViewExample/TransformerExampleViewController.swift
+++ b/FSPageViewExample-Swift/FSPagerViewExample/TransformerExampleViewController.swift
@@ -99,7 +99,7 @@ class TransformerExampleViewController: UIViewController,FSPagerViewDataSource,F
         return imageNames.count
     }
     
-    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell {
+    public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> UICollectionViewCell {
         let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as! FSPagerViewCell
         cell.imageView?.image = UIImage(named: self.imageNames[index])
         cell.imageView?.contentMode = .scaleAspectFill

--- a/FSPagerViewExample-Objc/FSPagerViewExample-Objc/BasicExampleViewController.m
+++ b/FSPagerViewExample-Objc/FSPagerViewExample-Objc/BasicExampleViewController.m
@@ -208,7 +208,7 @@
     return self.numberOfItems;
 }
 
-- (FSPagerViewBaseCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
+- (UICollectionViewCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
 {
     FSPagerViewCell *cell = (FSPagerViewCell *)[pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
     cell.imageView.image = [UIImage imageNamed:self.imageNames[index]];

--- a/FSPagerViewExample-Objc/FSPagerViewExample-Objc/BasicExampleViewController.m
+++ b/FSPagerViewExample-Objc/FSPagerViewExample-Objc/BasicExampleViewController.m
@@ -208,9 +208,9 @@
     return self.numberOfItems;
 }
 
-- (FSPagerViewCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
+- (FSPagerViewBaseCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
 {
-    FSPagerViewCell *cell = [pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
+    FSPagerViewCell *cell = (FSPagerViewCell *)[pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
     cell.imageView.image = [UIImage imageNamed:self.imageNames[index]];
     cell.imageView.contentMode = UIViewContentModeScaleAspectFill;
     cell.imageView.clipsToBounds = YES;

--- a/FSPagerViewExample-Objc/FSPagerViewExample-Objc/PageControlExampleViewController.m
+++ b/FSPagerViewExample-Objc/FSPagerViewExample-Objc/PageControlExampleViewController.m
@@ -150,7 +150,7 @@
     return self.imageNames.count;
 }
 
-- (FSPagerViewBaseCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
+- (UICollectionViewCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
 {
     FSPagerViewCell *cell = (FSPagerViewCell *)[pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
     cell.imageView.contentMode = UIViewContentModeScaleAspectFill;

--- a/FSPagerViewExample-Objc/FSPagerViewExample-Objc/PageControlExampleViewController.m
+++ b/FSPagerViewExample-Objc/FSPagerViewExample-Objc/PageControlExampleViewController.m
@@ -150,9 +150,9 @@
     return self.imageNames.count;
 }
 
-- (FSPagerViewCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
+- (FSPagerViewBaseCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
 {
-    FSPagerViewCell *cell = [pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
+    FSPagerViewCell *cell = (FSPagerViewCell *)[pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
     cell.imageView.contentMode = UIViewContentModeScaleAspectFill;
     cell.imageView.image = [UIImage imageNamed:self.imageNames[index]];
     return cell;

--- a/FSPagerViewExample-Objc/FSPagerViewExample-Objc/TransformerExampleViewController.m
+++ b/FSPagerViewExample-Objc/FSPagerViewExample-Objc/TransformerExampleViewController.m
@@ -80,9 +80,9 @@
     return self.imageNames.count;
 }
 
-- (FSPagerViewCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
+- (FSPagerViewBaseCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
 {
-    FSPagerViewCell * cell = [pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
+    FSPagerViewCell * cell = (FSPagerViewCell *)[pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
     cell.imageView.image = [UIImage imageNamed:self.imageNames[index]];
     cell.imageView.contentMode = UIViewContentModeScaleAspectFill;
     cell.imageView.clipsToBounds = YES;

--- a/FSPagerViewExample-Objc/FSPagerViewExample-Objc/TransformerExampleViewController.m
+++ b/FSPagerViewExample-Objc/FSPagerViewExample-Objc/TransformerExampleViewController.m
@@ -80,7 +80,7 @@
     return self.imageNames.count;
 }
 
-- (FSPagerViewBaseCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
+- (UICollectionViewCell *)pagerView:(FSPagerView *)pagerView cellForItemAtIndex:(NSInteger)index
 {
     FSPagerViewCell * cell = (FSPagerViewCell *)[pagerView dequeueReusableCellWithReuseIdentifier:@"cell" atIndex:index];
     cell.imageView.image = [UIImage imageNamed:self.imageNames[index]];

--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ public func numberOfItems(in pagerView: FSPagerView) -> Int {
     return numberOfItems
 }
     
-public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewCell {
-    let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index)
+public func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell {
+    let cell = pagerView.dequeueReusableCell(withReuseIdentifier: "cell", at: index) as! FSPagerViewCell
     cell.imageView?.image = ...
     cell.textLabel?.text = ...
     return cell
@@ -348,14 +348,14 @@ func pagerView(_ pagerView: FSPagerView, didSelectItemAt index: Int)
 ---
     
 ```swift
-func pagerView(_ pagerView: FSPagerView, willDisplay cell: FSPagerViewCell, forItemAt index: Int)
+func pagerView(_ pagerView: FSPagerView, willDisplay cell: FSPagerViewBaseCell, forItemAt index: Int)
 ```
 > Tells the delegate that the specified cell is about to be displayed in the pager view.
     
 ---
     
 ```swift
-func pagerView(_ pagerView: FSPagerView, didEndDisplaying cell: FSPagerViewCell, forItemAt index: Int)
+func pagerView(_ pagerView: FSPagerView, didEndDisplaying cell: FSPagerViewBaseCell, forItemAt index: Int)
 ```
 > Tells the delegate that the specified cell was removed from the pager view.
     

--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -21,7 +21,7 @@ public protocol FSPagerViewDataSource: NSObjectProtocol {
     
     /// Asks your data source object for the cell that corresponds to the specified item in the pager view.
     @objc(pagerView:cellForItemAtIndex:)
-    func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell
+    func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> UICollectionViewCell
     
 }
 
@@ -46,11 +46,11 @@ public protocol FSPagerViewDelegate: NSObjectProtocol {
     
     /// Tells the delegate that the specified cell is about to be displayed in the pager view.
     @objc(pagerView:willDisplayCell:forItemAtIndex:)
-    optional func pagerView(_ pagerView: FSPagerView, willDisplay cell: FSPagerViewBaseCell, forItemAt index: Int)
+    optional func pagerView(_ pagerView: FSPagerView, willDisplay cell: UICollectionViewCell, forItemAt index: Int)
     
     /// Tells the delegate that the specified cell was removed from the pager view.
     @objc(pagerView:didEndDisplayingCell:forItemAtIndex:)
-    optional func pagerView(_ pagerView: FSPagerView, didEndDisplaying cell: FSPagerViewBaseCell, forItemAt index: Int)
+    optional func pagerView(_ pagerView: FSPagerView, didEndDisplaying cell: UICollectionViewCell, forItemAt index: Int)
     
     /// Tells the delegate when the pager view is about to start scrolling the content.
     @objc(pagerViewWillBeginDragging:)
@@ -379,7 +379,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
             return
         }
         let index = indexPath.item % self.numberOfItems
-        function(self,cell as! FSPagerViewBaseCell,index)
+        function(self,cell,index)
     }
     
     public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
@@ -387,7 +387,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
             return
         }
         let index = indexPath.item % self.numberOfItems
-        function(self,cell as! FSPagerViewBaseCell,index)
+        function(self,cell,index)
     }
     
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -451,7 +451,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// Register a nib file for use in creating new pager view cells.
     ///
     /// - Parameters:
-    ///   - nib: The nib object containing the cell object. The nib file must contain only one top-level object and that object must be of the type FSPagerViewBaseCell.
+    ///   - nib: The nib object containing the cell object. The nib file must contain only one top-level object and that object must be of the type UICollectionViewCell.
     ///   - identifier: The reuse identifier to associate with the specified nib file. This parameter must not be nil and must not be an empty string.
     @objc(registerNib:forCellWithReuseIdentifier:)
     open func register(_ nib: UINib?, forCellWithReuseIdentifier identifier: String) {
@@ -463,15 +463,12 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// - Parameters:
     ///   - identifier: The reuse identifier for the specified cell. This parameter must not be nil.
     ///   - index: The index specifying the location of the cell.
-    /// - Returns: A valid FSPagerViewBaseCell object.
+    /// - Returns: A valid UICollectionViewCell object.
     @objc(dequeueReusableCellWithReuseIdentifier:atIndex:)
-    open func dequeueReusableCell(withReuseIdentifier identifier: String, at index: Int) -> FSPagerViewBaseCell {
+    open func dequeueReusableCell(withReuseIdentifier identifier: String, at index: Int) -> UICollectionViewCell {
         let indexPath = IndexPath(item: index, section: self.dequeingSection)
         let cell = self.collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath)
-        guard cell.isKind(of: FSPagerViewBaseCell.self) else {
-            fatalError("Cell class must be subclass of FSPagerViewBaseCell")
-        }
-        return cell as! FSPagerViewBaseCell
+        return cell
     }
     
     /// Reloads all of the data for the collection view.
@@ -532,7 +529,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// - Parameter cell: The cell object whose index you want.
     /// - Returns: The index of the cell or NSNotFound if the specified cell is not in the pager view.
     @objc(indexForCell:)
-    open func index(for cell: FSPagerViewBaseCell) -> Int {
+    open func index(for cell: UICollectionViewCell) -> Int {
         guard let indexPath = self.collectionView.indexPath(for: cell) else {
             return NSNotFound
         }
@@ -544,9 +541,9 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// - Parameter index: The index that specifies the position of the cell.
     /// - Returns: The cell object at the corresponding position or nil if the cell is not visible or index is out of range.
     @objc(cellForItemAtIndex:)
-    open func cellForItem(at index: Int) -> FSPagerViewBaseCell? {
+    open func cellForItem(at index: Int) -> UICollectionViewCell? {
         let indexPath = self.nearbyIndexPath(for: index)
-        return self.collectionView.cellForItem(at: indexPath) as? FSPagerViewBaseCell
+        return self.collectionView.cellForItem(at: indexPath)
     }
     
     // MARK: - Private functions

--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -21,7 +21,7 @@ public protocol FSPagerViewDataSource: NSObjectProtocol {
     
     /// Asks your data source object for the cell that corresponds to the specified item in the pager view.
     @objc(pagerView:cellForItemAtIndex:)
-    func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewCell
+    func pagerView(_ pagerView: FSPagerView, cellForItemAt index: Int) -> FSPagerViewBaseCell
     
 }
 
@@ -46,11 +46,11 @@ public protocol FSPagerViewDelegate: NSObjectProtocol {
     
     /// Tells the delegate that the specified cell is about to be displayed in the pager view.
     @objc(pagerView:willDisplayCell:forItemAtIndex:)
-    optional func pagerView(_ pagerView: FSPagerView, willDisplay cell: FSPagerViewCell, forItemAt index: Int)
+    optional func pagerView(_ pagerView: FSPagerView, willDisplay cell: FSPagerViewBaseCell, forItemAt index: Int)
     
     /// Tells the delegate that the specified cell was removed from the pager view.
     @objc(pagerView:didEndDisplayingCell:forItemAtIndex:)
-    optional func pagerView(_ pagerView: FSPagerView, didEndDisplaying cell: FSPagerViewCell, forItemAt index: Int)
+    optional func pagerView(_ pagerView: FSPagerView, didEndDisplaying cell: FSPagerViewBaseCell, forItemAt index: Int)
     
     /// Tells the delegate when the pager view is about to start scrolling the content.
     @objc(pagerViewWillBeginDragging:)
@@ -379,7 +379,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
             return
         }
         let index = indexPath.item % self.numberOfItems
-        function(self,cell as! FSPagerViewCell,index)
+        function(self,cell as! FSPagerViewBaseCell,index)
     }
     
     public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
@@ -387,7 +387,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
             return
         }
         let index = indexPath.item % self.numberOfItems
-        function(self,cell as! FSPagerViewCell,index)
+        function(self,cell as! FSPagerViewBaseCell,index)
     }
     
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -451,7 +451,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// Register a nib file for use in creating new pager view cells.
     ///
     /// - Parameters:
-    ///   - nib: The nib object containing the cell object. The nib file must contain only one top-level object and that object must be of the type FSPagerViewCell.
+    ///   - nib: The nib object containing the cell object. The nib file must contain only one top-level object and that object must be of the type FSPagerViewBaseCell.
     ///   - identifier: The reuse identifier to associate with the specified nib file. This parameter must not be nil and must not be an empty string.
     @objc(registerNib:forCellWithReuseIdentifier:)
     open func register(_ nib: UINib?, forCellWithReuseIdentifier identifier: String) {
@@ -463,15 +463,15 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// - Parameters:
     ///   - identifier: The reuse identifier for the specified cell. This parameter must not be nil.
     ///   - index: The index specifying the location of the cell.
-    /// - Returns: A valid FSPagerViewCell object.
+    /// - Returns: A valid FSPagerViewBaseCell object.
     @objc(dequeueReusableCellWithReuseIdentifier:atIndex:)
-    open func dequeueReusableCell(withReuseIdentifier identifier: String, at index: Int) -> FSPagerViewCell {
+    open func dequeueReusableCell(withReuseIdentifier identifier: String, at index: Int) -> FSPagerViewBaseCell {
         let indexPath = IndexPath(item: index, section: self.dequeingSection)
         let cell = self.collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath)
-        guard cell.isKind(of: FSPagerViewCell.self) else {
-            fatalError("Cell class must be subclass of FSPagerViewCell")
+        guard cell.isKind(of: FSPagerViewBaseCell.self) else {
+            fatalError("Cell class must be subclass of FSPagerViewBaseCell")
         }
-        return cell as! FSPagerViewCell
+        return cell as! FSPagerViewBaseCell
     }
     
     /// Reloads all of the data for the collection view.
@@ -532,7 +532,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// - Parameter cell: The cell object whose index you want.
     /// - Returns: The index of the cell or NSNotFound if the specified cell is not in the pager view.
     @objc(indexForCell:)
-    open func index(for cell: FSPagerViewCell) -> Int {
+    open func index(for cell: FSPagerViewBaseCell) -> Int {
         guard let indexPath = self.collectionView.indexPath(for: cell) else {
             return NSNotFound
         }
@@ -544,9 +544,9 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     /// - Parameter index: The index that specifies the position of the cell.
     /// - Returns: The cell object at the corresponding position or nil if the cell is not visible or index is out of range.
     @objc(cellForItemAtIndex:)
-    open func cellForItem(at index: Int) -> FSPagerViewCell? {
+    open func cellForItem(at index: Int) -> FSPagerViewBaseCell? {
         let indexPath = self.nearbyIndexPath(for: index)
-        return self.collectionView.cellForItem(at: indexPath) as? FSPagerViewCell
+        return self.collectionView.cellForItem(at: indexPath) as? FSPagerViewBaseCell
     }
     
     // MARK: - Private functions

--- a/Sources/FSPagerViewCell.swift
+++ b/Sources/FSPagerViewCell.swift
@@ -8,9 +8,7 @@
 
 import UIKit
 
-open class FSPagerViewBaseCell: UICollectionViewCell {}
-
-open class FSPagerViewCell: FSPagerViewBaseCell {
+open class FSPagerViewCell: UICollectionViewCell {
     
     /// Returns the label used for the main textual content of the pager view cell.
     @objc

--- a/Sources/FSPagerViewCell.swift
+++ b/Sources/FSPagerViewCell.swift
@@ -8,7 +8,9 @@
 
 import UIKit
 
-open class FSPagerViewCell: UICollectionViewCell {
+open class FSPagerViewBaseCell: UICollectionViewCell {}
+
+open class FSPagerViewCell: FSPagerViewBaseCell {
     
     /// Returns the label used for the main textual content of the pager view cell.
     @objc


### PR DESCRIPTION
Now a subclass of `FSPagerViewCell` is required to create a custom cell. 
However, `FSPagerViewCell` has a design that is unnecessary for customization such as adding shadows.
ref: https://github.com/WenchaoD/FSPagerView/blob/e535eb1a810dc76d99260a0ae3898f80ad73261e/Sources/FSPagerViewCell.swift#L104-L107

Also, there is no place in this library that uses the properties in `FSPagerViewCell`. 
Therefore, make use of the standard `UICollectionViewCell`.