### PR TITLE
将视图内左右间距参数开放出来，在一屏多图滑动时前后不会空0.5个item距离

### DIFF
--- a/Sources/FSPageViewLayout.swift
+++ b/Sources/FSPageViewLayout.swift
@@ -75,7 +75,7 @@ class FSPagerViewLayout: UICollectionViewLayout {
             return pagerView.interitemSpacing
         }()
         self.scrollDirection = pagerView.scrollDirection
-        self.leadingSpacing = self.scrollDirection == .horizontal ? (collectionView.frame.width-self.actualItemSize.width)*0.5 : (collectionView.frame.height-self.actualItemSize.height)*0.5
+        self.leadingSpacing = pagerView.leadingSpacing
         self.itemSpacing = (self.scrollDirection == .horizontal ? self.actualItemSize.width : self.actualItemSize.height) + self.actualInteritemSpacing
         
         // Calculate and cache contentSize, rather than calculating each time

--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -192,6 +192,14 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
         }
     }
     
+    /// The spacing to use leading items in the pager view. Default is 0.
+    @IBInspectable
+    open var leadingSpacing: CGFloat = 0 {
+        didSet {
+            self.collectionViewLayout.forceInvalidate()
+        }
+    }
+    
     // MARK: - Public readonly-properties
     
     /// Returns whether the user has touched the content to initiate scrolling.


### PR DESCRIPTION
已解决下面问题
https://github.com/WenchaoD/FSPagerView/issues/212