### PR TITLE
Fix - Crash issue with numberOfItems

### DIFF
--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -511,7 +511,7 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     ///   - animated: Specify true to animate the scrolling behavior or false to adjust the pager view’s visible content immediately.
     @objc(scrollToItemAtIndex:animated:)
     open func scrollToItem(at index: Int, animated: Bool) {
-        guard index < self.numberOfItems else {
+        guard index <= self.numberOfItems else {
             fatalError("index \(index) is out of range [0...\(self.numberOfItems-1)]")
         }
         let indexPath = { () -> IndexPath in


### PR DESCRIPTION
When numberOfItems and index both are zero causes crash