### PR TITLE
Easy to add rx extension

### DIFF
--- a/FSPagerViewExamples.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/FSPagerViewExamples.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/FSPagerCollectionView.swift
+++ b/Sources/FSPagerCollectionView.swift
@@ -10,10 +10,10 @@
 
 import UIKit
 
-class FSPagerCollectionView: UICollectionView {
+public class FSPagerCollectionView: UICollectionView {
     
     #if !os(tvOS)
-    override var scrollsToTop: Bool {
+    public override var scrollsToTop: Bool {
         set {
             super.scrollsToTop = false
         }
@@ -23,7 +23,7 @@ class FSPagerCollectionView: UICollectionView {
     }
     #endif
     
-    override var contentInset: UIEdgeInsets {
+    public override var contentInset: UIEdgeInsets {
         set {
             super.contentInset = .zero
             if (newValue.top > 0) {

--- a/Sources/FSPagerView.swift
+++ b/Sources/FSPagerView.swift
@@ -218,12 +218,13 @@ open class FSPagerView: UIView,UICollectionViewDataSource,UICollectionViewDelega
     
     // MARK: - Private properties
     
+    public weak var collectionView: FSPagerCollectionView!
+    public var numberOfItems: Int = 0
+    public var numberOfSections: Int = 0
+    
     internal weak var collectionViewLayout: FSPagerViewLayout!
-    internal weak var collectionView: FSPagerCollectionView!
     internal weak var contentView: UIView!
     internal var timer: Timer?
-    internal var numberOfItems: Int = 0
-    internal var numberOfSections: Int = 0
     
     fileprivate var dequeingSection = 0
     fileprivate var centermostIndexPath: IndexPath {


### PR DESCRIPTION
你好，为了更方便使用，需要给您的库添加Rx扩展
由于`FSPagerCollectionView`和`collectionView`、`numberOfItems`、`numberOfSections`等属性属于internal访问权限。
我不得不这样做，🥲

```
post_install do |installer|
  ## Fixed collectionView being internal
  find_and_replace("./Pods/FSPagerView/Sources/FSPagerCollectionView.swift", "class FSPagerCollectionView", "public class FSPagerCollectionView")
  find_and_replace("./Pods/FSPagerView/Sources/FSPagerCollectionView.swift", "override var scrollsToTop", "public override var scrollsToTop")
  find_and_replace("./Pods/FSPagerView/Sources/FSPagerCollectionView.swift", "override var contentInset", "public override var contentInset")
  
  find_and_replace("./Pods/FSPagerView/Sources/FSPagerView.swift", "internal weak var collectionView:", "public weak var collectionView:")
  find_and_replace("./Pods/FSPagerView/Sources/FSPagerView.swift", "internal var numberOfItems:", "public var numberOfItems:")
  find_and_replace("./Pods/FSPagerView/Sources/FSPagerView.swift", "internal var numberOfSections:", "public var numberOfSections:")
end

def find_and_replace(dir, findstr, replacestr)
  Dir[dir].each do |name|
    text = File.read(name)
    replace = text.gsub(findstr,replacestr)
    if text != replace
      puts "Fix: " + name
      File.open(name, "w") { |file| file.puts replace }
      STDOUT.flush
    end
  end
  Dir[dir + '*/'].each(&method(:find_and_replace))
end
```

但是这样很麻烦，因此我这边帮你改好访问权限。 希望您看看；

谢谢🙏