### PR TITLE
Fix swift-tools-version comment spacing in Swift.package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
got this error
`the manifest is backward-incompatible with Swift < 6.0 because the tools-version was specified in a subsequent line of the manifest, not the first line. Either move the tools-version specification or increase the required tools-version of your manifest`

this was caused because the swift-tools-version comment have no spacing
`// swift-tools-version:5.9`

it should be
`// swift-tools-version: 5.9`